### PR TITLE
Halo2 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ merlin = { version = "3.0.0", default-features = false }
 halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "release-0.4.0-rc" }
 
 poseidon-native = { git = "https://github.com/privacy-scaling-explorations/poseidon", package = "poseidon" }
+criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = { version = "^0.4.0", default-features = false }
@@ -37,6 +38,11 @@ ark-bls12-377 = { version = "^0.4.0", default-features = false, features = [ "cu
 ark-bn254 = { version = "^0.4.0", default-features = false, features = [ "curve" ] }
 blake2 = { version = "0.10", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
+
+[[bench]]
+name = "pcs"
+path = "benches/benches.rs"
+harness = false
 
 [profile.release]
 opt-level = 3
@@ -56,6 +62,7 @@ std = [ "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", "ark-relation
 r1cs = [ "ark-relations", "ark-r1cs-std", "hashbrown", "ark-crypto-primitives/r1cs"]
 print-trace = [ "ark-std/print-trace" ]
 parallel = [ "std", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "ark-std/parallel", "rayon" ]
+benches = [ "std", "criterion" ]
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ digest = "0.10"
 derivative = { version = "2", features = [ "use_core" ] }
 rayon = { version = "1", optional = true }
 merlin = { version = "3.0.0", default-features = false }
-halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-ce" }
-poseidon-native = { git = "https://github.com/scroll-tech/poseidon/", package = "poseidon"}
+halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", branch = "release-0.4.0-rc" }
+
+poseidon-native = { git = "https://github.com/privacy-scaling-explorations/poseidon", package = "poseidon" }
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = { version = "^0.4.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,14 @@ digest = "0.10"
 derivative = { version = "2", features = [ "use_core" ] }
 rayon = { version = "1", optional = true }
 merlin = { version = "3.0.0", default-features = false }
+halo2-base = { git = "https://github.com/axiom-crypto/halo2-lib", tag = "v0.3.0-ce" }
+poseidon-native = { git = "https://github.com/scroll-tech/poseidon/", package = "poseidon"}
 
 [dev-dependencies]
 ark-ed-on-bls12-381 = { version = "^0.4.0", default-features = false }
 ark-bls12-381 = { version = "^0.4.0", default-features = false, features = [ "curve" ] }
 ark-bls12-377 = { version = "^0.4.0", default-features = false, features = [ "curve" ] }
+ark-bn254 = { version = "^0.4.0", default-features = false, features = [ "curve" ] }
 blake2 = { version = "0.10", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
 
@@ -57,13 +60,14 @@ parallel = [ "std", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly"}
-ark-ec = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly"}
-ark-poly = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly"}
-ark-serialize = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly"}
+ark-ff = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly" }
+ark-ec = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly" }
+ark-poly = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly" }
+ark-serialize = { git = "https://github.com/HungryCatsStudio/algebra", branch = "ml-is-poly" }
 
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
 
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }
+ark-bn254 = { git = "https://github.com/arkworks-rs/curves/" }

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,196 @@
+#![cfg(feature = "benches")]
+use std::{borrow::Borrow, marker::PhantomData};
+
+use ark_ff::PrimeField;
+use ark_std::{rand::RngCore, test_rng};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use ark_crypto_primitives::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    merkle_tree::{Config, IdentityDigestConverter},
+    sponge::{
+        poseidon::{PoseidonConfig, PoseidonSponge},
+        Absorb, CryptographicSponge,
+    },
+    Error,
+};
+
+use ark_poly_commit::{
+    bench_templates::{bench_pcs_method, commit, open, verify, MLE},
+    linear_codes::{LinearCodePCS, MultilinearLigero},
+};
+
+/// Generate default parameters for alpha = 17, state-size = 8
+///
+/// WARNING: This poseidon parameter is not secure. Please generate
+/// your own parameters according the field you use.
+pub fn poseidon_parameters_for_test<F: PrimeField>() -> PoseidonConfig<F> {
+    let full_rounds = 8;
+    let partial_rounds = 31;
+    let alpha = 17;
+
+    let mds = vec![
+        vec![F::one(), F::zero(), F::one()],
+        vec![F::one(), F::one(), F::zero()],
+        vec![F::zero(), F::one(), F::one()],
+    ];
+
+    let mut ark = Vec::new();
+    let mut ark_rng = test_rng();
+
+    for _ in 0..(full_rounds + partial_rounds) {
+        let mut res = Vec::new();
+
+        for _ in 0..3 {
+            res.push(F::rand(&mut ark_rng));
+        }
+        ark.push(res);
+    }
+    PoseidonConfig::new(full_rounds, partial_rounds, alpha, mds, ark, 2, 1)
+}
+
+use ark_bn254::Fr as Fr254;
+
+// We introduce the wrapper only for the purpose of `setup` function not panicing with unimplemented
+struct PoseidonWrapper<F>(PhantomData<F>);
+
+impl<F: PrimeField + Absorb> CRHScheme for PoseidonWrapper<F> {
+    type Input = [F];
+    type Output = F;
+    type Parameters = PoseidonConfig<F>;
+
+    fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(poseidon_parameters_for_test())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        parameters: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, Error> {
+        let input = input.borrow();
+
+        let mut sponge = PoseidonSponge::new(parameters);
+        sponge.absorb(&input);
+        let res = sponge.squeeze_field_elements::<F>(1);
+        Ok(res[0])
+    }
+}
+
+impl<F: PrimeField + Absorb> TwoToOneCRHScheme for PoseidonWrapper<F> {
+    type Input = F;
+    type Output = F;
+    type Parameters = PoseidonConfig<F>;
+
+    fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(poseidon_parameters_for_test())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        let left_input = left_input.borrow();
+        let right_input = right_input.borrow();
+
+        let mut sponge = PoseidonSponge::new(parameters);
+        sponge.absorb(left_input);
+        sponge.absorb(right_input);
+        let res = sponge.squeeze_field_elements::<F>(1);
+        Ok(res[0])
+    }
+
+    fn compress<T: Borrow<Self::Output>>(
+        parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        let left_input = left_input.borrow();
+        let right_input = right_input.borrow();
+
+        let mut sponge = PoseidonSponge::new(parameters);
+        sponge.absorb(left_input);
+        sponge.absorb(right_input);
+        let res = sponge.squeeze_field_elements::<F>(1);
+        Ok(res[0])
+    }
+}
+
+struct LeafIdentityHasher<F>(PhantomData<F>);
+
+impl<F: PrimeField> CRHScheme for LeafIdentityHasher<F> {
+    type Input = F;
+    type Output = F;
+    type Parameters = ();
+
+    fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        _: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, Error> {
+        Ok(*input.borrow())
+    }
+}
+struct MerkleTreeParams<F>(PhantomData<F>);
+
+impl<F: PrimeField + Absorb> Config for MerkleTreeParams<F> {
+    type Leaf = F;
+
+    type LeafDigest = <LeafIdentityHasher<F> as CRHScheme>::Output;
+    type LeafInnerDigestConverter = IdentityDigestConverter<Self::LeafDigest>;
+    type InnerDigest = <CompressH<F> as TwoToOneCRHScheme>::Output;
+
+    type LeafHash = LeafIdentityHasher<F>;
+    type TwoToOneHash = CompressH<F>;
+}
+
+type MTConfig<F> = MerkleTreeParams<F>;
+type Sponge<F> = PoseidonSponge<F>;
+
+type ColHasher<F> = PoseidonWrapper<F>;
+type CompressH<F> = PoseidonWrapper<F>;
+type Ligero<F> = LinearCodePCS<
+    MultilinearLigero<F, MTConfig<F>, Sponge<F>, MLE<F>>,
+    F,
+    MLE<F>,
+    Sponge<F>,
+    MTConfig<F>,
+    ColHasher<F>,
+>;
+
+const MIN_NUM_VARS: usize = 10;
+const MAX_NUM_VARS: usize = 20;
+
+fn ligero_bn254(c: &mut Criterion) {
+    bench_pcs_method::<_, Ligero<Fr254>>(
+        c,
+        (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
+        "commit_ligero_range_BN_254",
+        commit::<_, Ligero<Fr254>>,
+    );
+    bench_pcs_method::<_, Ligero<Fr254>>(
+        c,
+        (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
+        "open_ligero_range_BN_254",
+        open::<_, Ligero<Fr254>>,
+    );
+
+    bench_pcs_method::<_, Ligero<Fr254>>(
+        c,
+        (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
+        "verify_ligero_range_BN_254",
+        verify::<_, Ligero<Fr254>>,
+    );
+}
+
+criterion_group! {
+    name = ligero_benches;
+    config = Criterion::default();
+    targets =
+        ligero_bn254,
+}
+
+criterion_main!(ligero_benches);

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -165,6 +165,7 @@ const MIN_NUM_VARS: usize = 10;
 const MAX_NUM_VARS: usize = 20;
 
 fn ligero_bn254(c: &mut Criterion) {
+    // only commit and open; verify is done in-circuit!
     bench_pcs_method::<_, Ligero<Fr254>>(
         c,
         (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
@@ -176,13 +177,6 @@ fn ligero_bn254(c: &mut Criterion) {
         (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
         "open_ligero_range_BN_254",
         open::<_, Ligero<Fr254>>,
-    );
-
-    bench_pcs_method::<_, Ligero<Fr254>>(
-        c,
-        (MIN_NUM_VARS..MAX_NUM_VARS).step_by(2).collect(),
-        "verify_ligero_range_BN_254",
-        verify::<_, Ligero<Fr254>>,
     );
 }
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -161,8 +161,8 @@ type Ligero<F> = LinearCodePCS<
     ColHasher<F>,
 >;
 
-const MIN_NUM_VARS: usize = 10;
-const MAX_NUM_VARS: usize = 20;
+const MIN_NUM_VARS: usize = 12;
+const MAX_NUM_VARS: usize = 22;
 
 fn ligero_bn254(c: &mut Criterion) {
     // only commit and open; verify is done in-circuit!

--- a/src/bench_templates/mod.rs
+++ b/src/bench_templates/mod.rs
@@ -41,7 +41,13 @@ pub fn bench_pcs_method<
             BenchmarkId::from_parameter(num_vars),
             &num_vars,
             |b, num_vars| {
-                b.iter(|| method(&pp, *num_vars));
+                b.iter_custom(|i| {
+                    let mut time = Duration::from_nanos(0);
+                    for _ in 0..i {
+                        time += method(&pp, *num_vars);
+                    }
+                    time
+                });
             },
         );
     }

--- a/src/bench_templates/mod.rs
+++ b/src/bench_templates/mod.rs
@@ -1,0 +1,178 @@
+use ark_crypto_primitives::sponge::{
+    poseidon::{PoseidonConfig, PoseidonSponge},
+    CryptographicSponge,
+};
+use ark_ff::PrimeField;
+use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+use ark_std::{rand::Rng, test_rng};
+
+/// type alias for DenseMultilinearExtension
+pub type MLE<F> = DenseMultilinearExtension<F>;
+
+use core::time::Duration;
+use std::time::Instant;
+
+use crate::{challenge::ChallengeGenerator, LabeledPolynomial, PolynomialCommitment};
+
+use criterion::{BenchmarkId, Criterion};
+
+/// Measure the time cost of {commit/open/verify} across a range of num_vars
+pub fn bench_pcs_method<
+    F: PrimeField,
+    PCS: PolynomialCommitment<F, DenseMultilinearExtension<F>, PoseidonSponge<F>>,
+>(
+    c: &mut Criterion,
+    range: Vec<usize>,
+    msg: &str,
+    method: impl Fn(&PCS::UniversalParams, usize) -> Duration,
+) {
+    let mut group = c.benchmark_group(msg);
+    let rng = &mut test_rng();
+
+    // Add for logarithmic scale (should yield linear plots)
+    // let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    // group.plot_config(plot_config);
+
+    for num_vars in range {
+        // TODO if this takes too long and key trimming works, we might want to pull this out from the loop
+        let pp = PCS::setup(1, Some(num_vars), rng).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |b, num_vars| {
+                b.iter(|| method(&pp, *num_vars));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Report the time cost of a commitment
+pub fn commit<
+    F: PrimeField,
+    PCS: PolynomialCommitment<F, DenseMultilinearExtension<F>, PoseidonSponge<F>>,
+>(
+    pp: &PCS::UniversalParams,
+    num_vars: usize,
+) -> Duration {
+    // TODO create or pass? depends on the cost
+    let rng = &mut test_rng();
+
+    let (ck, _) = PCS::trim(&pp, 1, 1, None).unwrap();
+
+    let labeled_poly =
+        LabeledPolynomial::new("test".to_string(), rand_ml_poly(num_vars, rng), None, None);
+
+    let start = Instant::now();
+    let (_, _) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    start.elapsed()
+}
+
+/// Report the time cost of an opening
+pub fn open<
+    F: PrimeField,
+    PCS: PolynomialCommitment<F, DenseMultilinearExtension<F>, PoseidonSponge<F>>,
+>(
+    pp: &PCS::UniversalParams,
+    num_vars: usize,
+) -> Duration {
+    let rng = &mut test_rng();
+    let (ck, _) = PCS::trim(&pp, 1, 1, None).unwrap();
+    let labeled_poly =
+        LabeledPolynomial::new("test".to_string(), rand_ml_poly(num_vars, rng), None, None);
+
+    let (coms, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let point = rand_mv_point(num_vars, rng);
+
+    let start = Instant::now();
+    let _ = PCS::open(
+        &ck,
+        [&labeled_poly],
+        &coms,
+        &point,
+        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &randomness,
+        Some(rng),
+    )
+    .unwrap();
+    start.elapsed()
+}
+
+/// Report the time cost of a verification
+pub fn verify<
+    F: PrimeField,
+    PCS: PolynomialCommitment<F, DenseMultilinearExtension<F>, PoseidonSponge<F>>,
+>(
+    pp: &PCS::UniversalParams,
+    num_vars: usize,
+) -> Duration {
+    let rng = &mut test_rng();
+    let (ck, vk) = PCS::trim(&pp, 1, 1, None).unwrap();
+    let labeled_poly =
+        LabeledPolynomial::new("test".to_string(), rand_ml_poly(num_vars, rng), None, None);
+
+    let (coms, randomness) = PCS::commit(&ck, [&labeled_poly], Some(rng)).unwrap();
+    let point = rand_mv_point(num_vars, rng);
+    let claimed_eval = labeled_poly.evaluate(&point);
+    let proof = PCS::open(
+        &ck,
+        [&labeled_poly],
+        &coms,
+        &point,
+        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &randomness,
+        Some(rng),
+    )
+    .unwrap();
+
+    let start = Instant::now();
+    PCS::check(
+        &vk,
+        &coms,
+        &point,
+        [claimed_eval],
+        &proof,
+        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        None,
+    )
+    .unwrap();
+    start.elapsed()
+}
+
+/*************** Auxiliary functions ***************/
+
+fn rand_ml_poly<F: PrimeField>(num_vars: usize, rng: &mut impl Rng) -> MLE<F> {
+    MLE::rand(num_vars, rng)
+}
+
+fn rand_mv_point<F: PrimeField>(num_vars: usize, rng: &mut impl Rng) -> Vec<F> {
+    (0..num_vars).map(|_| F::rand(rng)).collect()
+}
+
+fn test_sponge<F: PrimeField>() -> PoseidonSponge<F> {
+    let full_rounds = 8;
+    let partial_rounds = 31;
+    let alpha = 17;
+
+    let mds = vec![
+        vec![F::one(), F::zero(), F::one()],
+        vec![F::one(), F::one(), F::zero()],
+        vec![F::zero(), F::one(), F::one()],
+    ];
+
+    let mut v = Vec::new();
+    let mut ark_rng = test_rng();
+
+    for _ in 0..(full_rounds + partial_rounds) {
+        let mut res = Vec::new();
+
+        for _ in 0..3 {
+            res.push(F::rand(&mut ark_rng));
+        }
+        v.push(res);
+    }
+    let config = PoseidonConfig::new(full_rounds, partial_rounds, alpha, mds, v, 2, 1);
+    PoseidonSponge::new(&config)
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub enum Error {
     /// This means the required soundness error bound is inherently impossible.
     /// E.g., the field is not big enough.
     InvalidParameters(String),
+
+    /// Error resulting from hashing in linear code - based PCS.
+    HashingError,
 }
 
 impl core::fmt::Display for Error {
@@ -193,6 +196,7 @@ impl core::fmt::Display for Error {
             Error::InvalidCommitment => write!(f, "Failed to verify the commitment"),
             Error::TranscriptError => write!(f, "Incorrect transcript manipulation"),
             Error::InvalidParameters(err) => write!(f, "{}", err),
+            Error::HashingError => write!(f, "Error resulting from hashing")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,10 @@ use ark_std::{
 pub mod data_structures;
 pub use data_structures::*;
 
+/// benches
+#[cfg(feature = "benches")]
+pub mod bench_templates;
+
 /// R1CS constraints for polynomial constraints.
 #[cfg(feature = "r1cs")]
 mod constraints;

--- a/src/linear_codes/data_structures.rs
+++ b/src/linear_codes/data_structures.rs
@@ -191,10 +191,14 @@ impl<Unprepared: PCVerifierKey> PCPreparedVerifierKey<Unprepared> for LinCodePCP
 }
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Default(bound = ""), Clone(bound = ""), Debug(bound = ""))]
-pub(crate) struct Metadata {
-    pub(crate) n_rows: usize,
-    pub(crate) n_cols: usize,
-    pub(crate) n_ext_cols: usize,
+/// Metadata about the PCS
+pub struct Metadata {
+    /// The number of rows of the matrix
+    pub n_rows: usize,
+    /// The number of columns of the matrix
+    pub n_cols: usize,
+    /// The number of columns of the matrix after encoding
+    pub n_ext_cols: usize,
 }
 
 /// The commitment to a polynomial is a root of the merkle tree,

--- a/src/linear_codes/data_structures.rs
+++ b/src/linear_codes/data_structures.rs
@@ -206,9 +206,10 @@ pub struct Metadata {
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Default(bound = ""), Clone(bound = ""), Debug(bound = ""))]
 pub struct LinCodePCCommitment<C: Config> {
-    // number of rows resp. columns of the square matrix containing the coefficients of the polynomial
-    pub(crate) metadata: Metadata,
-    pub(crate) root: C::InnerDigest,
+    /// number of rows resp. columns of the square matrix containing the coefficients of the polynomial
+    pub metadata: Metadata,
+    /// The actual commitment
+    pub root: C::InnerDigest,
 }
 
 impl<C: Config> PCCommitment for LinCodePCCommitment<C> {

--- a/src/linear_codes/data_structures.rs
+++ b/src/linear_codes/data_structures.rs
@@ -252,18 +252,19 @@ impl PCRandomness for LinCodePCRandomness {
 /// Proof of an individual linear code well-formedness check or opening
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Default(bound = ""), Clone(bound = ""), Debug(bound = ""))]
-pub(crate) struct LinCodePCProofSingle<F, C>
+pub struct LinCodePCProofSingle<F, C>
 where
     F: PrimeField,
     C: Config,
 {
     /// For each of the indices in q, `paths` contains the path from the root of the merkle tree to the leaf
-    pub(crate) paths: Vec<Path<C>>,
+    pub paths: Vec<Path<C>>,
 
     /// v, s.t. E(v) = w
-    pub(crate) v: Vec<F>,
+    pub v: Vec<F>,
 
-    pub(crate) columns: Vec<Vec<F>>,
+    /// Columns that are opened
+    pub columns: Vec<Vec<F>>,
 }
 
 /// The Proof type for linear code PCS, which amounts to an array of individual proofs

--- a/src/linear_codes/data_structures.rs
+++ b/src/linear_codes/data_structures.rs
@@ -275,7 +275,7 @@ where
     F: PrimeField,
     C: Config,
 {
-    pub(crate) opening: LinCodePCProofSingle<F, C>,
+    pub opening: LinCodePCProofSingle<F, C>,
     pub(crate) well_formedness: Option<Vec<F>>,
 }
 

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -81,23 +81,6 @@ where
     fn tensor(point: &P::Point, left_len: usize, right_len: usize) -> (Vec<F>, Vec<F>);
 }
 
-// pub trait ColumnHasher<F, C, H>
-// where
-//     F: PrimeField,
-//     C: Config,
-//     H: CRHScheme,
-// {
-//     fn hash_column(column: &[F], params: H::Parameters) -> C::LeafDigest;
-// }
-
-// pub struct FieldColHasher<F, C, H>
-// where
-//     F: PrimeField,
-//     C: Config,
-//     H: CRHScheme,
-// {
-//     _phantom: PhantomData<(F, C, H)>,
-// }
 
 /// Any linear-code-based commitment scheme.
 pub struct LinearCodePCS<L, F, P, S, C, D, H>

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -14,6 +14,7 @@ use digest::Digest;
 use crate::linear_codes::utils::*;
 use crate::{Error, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 
+mod transcript;
 mod utils;
 
 mod multilinear_ligero;
@@ -31,6 +32,8 @@ pub use data_structures::{
 };
 
 use utils::{calculate_t, get_indices_from_transcript};
+
+use self::transcript::IOPTranscript;
 
 const FIELD_SIZE_ERROR: &str = "This field is not suitable for the proposed parameters";
 
@@ -80,7 +83,6 @@ where
     /// Tensor the point
     fn tensor(point: &P::Point, left_len: usize, right_len: usize) -> (Vec<F>, Vec<F>);
 }
-
 
 /// Any linear-code-based commitment scheme.
 pub struct LinearCodePCS<L, F, P, S, C, D, H>

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -29,8 +29,8 @@ mod data_structures;
 use data_structures::*;
 
 pub use data_structures::{
-    LinCodePCCommitment, LinCodePCCommitterKey, LinCodePCProof, LinCodePCUniversalParams,
-    LinCodePCVerifierKey, Metadata,
+    LinCodePCCommitment, LinCodePCCommitterKey, LinCodePCProof, LinCodePCProofSingle,
+    LinCodePCUniversalParams, LinCodePCVerifierKey, Metadata,
 };
 
 use utils::{calculate_t, get_indices_from_transcript, hash_column};

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -29,7 +29,8 @@ mod data_structures;
 use data_structures::*;
 
 pub use data_structures::{
-    LinCodePCCommitterKey, LinCodePCProof, LinCodePCUniversalParams, LinCodePCVerifierKey, Metadata,
+    LinCodePCCommitment, LinCodePCCommitterKey, LinCodePCProof, LinCodePCUniversalParams,
+    LinCodePCVerifierKey, Metadata,
 };
 
 use utils::{calculate_t, get_indices_from_transcript, hash_column};

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -16,10 +16,10 @@ mod transcript;
 mod utils;
 
 mod multilinear_ligero;
-// mod univariate_ligero;
+mod univariate_ligero;
 
 pub use multilinear_ligero::MultilinearLigero;
-// pub use univariate_ligero::UnivariateLigero;
+pub use univariate_ligero::UnivariateLigero;
 
 mod data_structures;
 use data_structures::*;

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -340,7 +340,6 @@ where
                 )?,
                 well_formedness,
             });
-            println!("{}", transcript);
         }
 
         Ok(proof_array)

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -29,7 +29,7 @@ mod data_structures;
 use data_structures::*;
 
 pub use data_structures::{
-    LinCodePCCommitterKey, LinCodePCProof, LinCodePCUniversalParams, LinCodePCVerifierKey,
+    LinCodePCCommitterKey, LinCodePCProof, LinCodePCUniversalParams, LinCodePCVerifierKey, Metadata,
 };
 
 use utils::{calculate_t, get_indices_from_transcript, hash_column};

--- a/src/linear_codes/mod.rs
+++ b/src/linear_codes/mod.rs
@@ -9,8 +9,6 @@ use ark_std::rand::RngCore;
 use ark_std::string::ToString;
 use ark_std::vec::Vec;
 
-use digest::Digest;
-
 use crate::linear_codes::utils::*;
 use crate::{Error, LabeledCommitment, LabeledPolynomial, PCUniversalParams, PolynomialCommitment};
 
@@ -38,12 +36,11 @@ use self::transcript::IOPTranscript;
 const FIELD_SIZE_ERROR: &str = "This field is not suitable for the proposed parameters";
 
 /// A trait for linear encoding a messsage.
-pub trait LinearEncode<F, P, C, D>
+pub trait LinearEncode<F, P, C>
 where
     F: PrimeField,
     P: Polynomial<F>,
     C: Config,
-    D: Digest,
 {
     /// Encode a message, which is interpreted as a vector of coefficients
     /// of a polynomial of degree m - 1.
@@ -81,22 +78,21 @@ where
 }
 
 /// Any linear-code-based commitment scheme.
-pub struct LinearCodePCS<L, F, P, S, C, D, H>
+pub struct LinearCodePCS<L, F, P, S, C, H>
 where
     F: PrimeField,
     C: Config,
-    D: Digest,
     S: CryptographicSponge,
     P: Polynomial<F>,
     H: CRHScheme,
-    L: LinearEncode<F, P, C, D>,
+    L: LinearEncode<F, P, C>,
 {
-    _phantom: PhantomData<(L, F, P, S, C, D, H)>,
+    _phantom: PhantomData<(L, F, P, S, C, H)>,
 }
 
-impl<L, F, P, S, C, D, H> PolynomialCommitment<F, P, S> for LinearCodePCS<L, F, P, S, C, D, H>
+impl<L, F, P, S, C, H> PolynomialCommitment<F, P, S> for LinearCodePCS<L, F, P, S, C, H>
 where
-    L: LinearEncode<F, P, C, D>,
+    L: LinearEncode<F, P, C>,
     F: PrimeField,
     P: Polynomial<F>,
     S: CryptographicSponge,
@@ -104,7 +100,6 @@ where
     Vec<F>: Borrow<<H as CRHScheme>::Input>,
     H::Output: Into<C::Leaf>,
     C::Leaf: Sized + Clone + Default,
-    D: Digest,
     H: CRHScheme,
 {
     type UniversalParams = LinCodePCUniversalParams<F, C, H>;

--- a/src/linear_codes/multilinear_ligero/mod.rs
+++ b/src/linear_codes/multilinear_ligero/mod.rs
@@ -31,7 +31,7 @@ where
     C: Config,
     S: CryptographicSponge,
     P: MultilinearExtension<F>,
-    <P as Polynomial<F>>::Point: Into<Vec<F>>,
+    P::Point: Into<Vec<F>>,
 {
     fn encode(msg: &[F], rho_inv: usize) -> Vec<F> {
         reed_solomon(msg, rho_inv)

--- a/src/linear_codes/multilinear_ligero/mod.rs
+++ b/src/linear_codes/multilinear_ligero/mod.rs
@@ -5,8 +5,6 @@ use ark_std::log2;
 use ark_std::marker::PhantomData;
 use ark_std::vec::Vec;
 
-use digest::Digest;
-
 use super::utils::reed_solomon;
 use super::LinearEncode;
 
@@ -21,18 +19,16 @@ mod tests;
 pub struct MultilinearLigero<
     F: PrimeField,
     C: Config,
-    D: Digest,
     S: CryptographicSponge,
     P: MultilinearExtension<F>,
 > {
-    _phantom: PhantomData<(F, C, D, S, P)>,
+    _phantom: PhantomData<(F, C, S, P)>,
 }
 
-impl<F, C, D, S, P> LinearEncode<F, P, C, D> for MultilinearLigero<F, C, D, S, P>
+impl<F, C, S, P> LinearEncode<F, P, C> for MultilinearLigero<F, C, S, P>
 where
     F: PrimeField,
     C: Config,
-    D: Digest,
     S: CryptographicSponge,
     P: MultilinearExtension<F>,
     <P as Polynomial<F>>::Point: Into<Vec<F>>,

--- a/src/linear_codes/multilinear_ligero/mod.rs
+++ b/src/linear_codes/multilinear_ligero/mod.rs
@@ -1,7 +1,6 @@
 use ark_crypto_primitives::{merkle_tree::Config, sponge::CryptographicSponge};
 use ark_ff::PrimeField;
 use ark_poly::{MultilinearExtension, Polynomial};
-use ark_std::borrow::Borrow;
 use ark_std::log2;
 use ark_std::marker::PhantomData;
 use ark_std::vec::Vec;
@@ -36,7 +35,6 @@ where
     D: Digest,
     S: CryptographicSponge,
     P: MultilinearExtension<F>,
-    Vec<u8>: Borrow<C::Leaf>,
     <P as Polynomial<F>>::Point: Into<Vec<F>>,
 {
     fn encode(msg: &[F], rho_inv: usize) -> Vec<F> {

--- a/src/linear_codes/multilinear_ligero/mod.rs
+++ b/src/linear_codes/multilinear_ligero/mod.rs
@@ -45,16 +45,12 @@ where
         polynomial.to_evaluations()
     }
 
-    fn point_to_vec(point: <P as Polynomial<F>>::Point) -> Vec<F> {
-        point.into()
-    }
-
     fn tensor(
         point: &<P as Polynomial<F>>::Point,
         left_len: usize,
         _right_len: usize,
     ) -> (Vec<F>, Vec<F>) {
-        let point: Vec<F> = Self::point_to_vec(point.clone());
+        let point: Vec<F> = point.clone().into();
 
         let split = log2(left_len) as usize;
         let left = &point[..split];

--- a/src/linear_codes/multilinear_ligero/tests.rs
+++ b/src/linear_codes/multilinear_ligero/tests.rs
@@ -52,7 +52,6 @@ mod tests {
         }
     }
 
-    // also implement TwoToOneCRHScheme for PoseidonWrapper
     impl<F: PrimeField + Absorb> TwoToOneCRHScheme for PoseidonWrapper<F> {
         type Input = F;
         type Output = F;
@@ -115,7 +114,7 @@ mod tests {
         }
     }
 
-    struct MerkleTreeParams<F>(PhantomData<F>); //<F, D>(PhantomData<(F, D)>);
+    struct MerkleTreeParams<F>(PhantomData<F>);
 
     impl<F: PrimeField + Absorb> Config for MerkleTreeParams<F> {
         type Leaf = F;

--- a/src/linear_codes/multilinear_ligero/tests.rs
+++ b/src/linear_codes/multilinear_ligero/tests.rs
@@ -13,7 +13,6 @@ mod tests {
         LabeledPolynomial, PolynomialCommitment,
     };
     use ark_bn254::Fr;
-    // use ark_bls12_377::Fr;
     use ark_crypto_primitives::merkle_tree::IdentityDigestConverter;
     use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
     use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
@@ -26,7 +25,6 @@ mod tests {
     use ark_ff::{Field, PrimeField};
     use ark_poly::evaluations::multivariate::{MultilinearExtension, SparseMultilinearExtension};
     use ark_std::test_rng;
-    use blake2::Blake2s256;
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
     // We introduce the wrapper only for the purpose of `setup` function not panicing with unimplemented
@@ -130,16 +128,15 @@ mod tests {
         type TwoToOneHash = CompressH<F>;
     }
 
-    type MTConfig<F> = MerkleTreeParams<F>; //<F, Blake2s256>;
+    type MTConfig<F> = MerkleTreeParams<F>; 
     type Sponge<F> = PoseidonSponge<F>;
 
     type LigeroPCS<F> = LinearCodePCS<
-        MultilinearLigero<F, MTConfig<F>, Blake2s256, Sponge<F>, SparseMultilinearExtension<F>>,
+        MultilinearLigero<F, MTConfig<F>, Sponge<F>, SparseMultilinearExtension<F>>,
         F,
         SparseMultilinearExtension<F>,
         Sponge<F>,
         MTConfig<F>,
-        Blake2s256,
         ColHasher<F>,
     >;
 

--- a/src/linear_codes/multilinear_ligero/tests.rs
+++ b/src/linear_codes/multilinear_ligero/tests.rs
@@ -1,17 +1,21 @@
 #[cfg(test)]
 mod tests {
 
+    use core::borrow::Borrow;
+    use core::marker::PhantomData;
+
     use crate::linear_codes::LinearCodePCS;
+    use crate::to_bytes;
+    use crate::RngCore;
     use crate::{
         challenge::ChallengeGenerator,
-        linear_codes::{
-            utils::*, LinCodePCUniversalParams, MultilinearLigero, PolynomialCommitment,
-        },
-        LabeledPolynomial,
+        linear_codes::{utils::*, LinCodePCUniversalParams, MultilinearLigero},
+        LabeledPolynomial, PolynomialCommitment,
     };
     use ark_bls12_377::Fq;
     use ark_bls12_377::Fr;
     use ark_bls12_381::Fr as Fr381;
+    use ark_crypto_primitives::Error;
     use ark_crypto_primitives::{
         crh::{pedersen, sha256::Sha256, CRHScheme, TwoToOneCRHScheme},
         merkle_tree::{ByteDigestConverter, Config},
@@ -19,8 +23,10 @@ mod tests {
     };
     use ark_ff::{Field, PrimeField};
     use ark_poly::evaluations::multivariate::{MultilinearExtension, SparseMultilinearExtension};
+    use ark_serialize::CanonicalSerialize;
     use ark_std::test_rng;
     use blake2::Blake2s256;
+    use digest::Digest;
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
     #[derive(Clone)]
@@ -30,13 +36,64 @@ mod tests {
         const NUM_WINDOWS: usize = 256;
     }
 
-    type LeafH = Sha256;
+    type LeafH = LeafIdentityHasher;
     type CompressH = Sha256;
+    type ColHasher<F, D> = FieldToBytesColHasher<F, D>;
 
-    struct MerkleTreeParams;
+    struct FieldToBytesColHasher<F, D>
+    where
+        F: PrimeField + CanonicalSerialize,
+        D: Digest,
+    {
+        _phantom: PhantomData<(F, D)>,
+    }
+
+    impl<F, D> CRHScheme for FieldToBytesColHasher<F, D>
+    where
+        F: PrimeField + CanonicalSerialize,
+        D: Digest,
+    {
+        type Input = Vec<F>;
+        type Output = Vec<u8>;
+        type Parameters = ();
+
+        fn setup<R: RngCore>(_rng: &mut R) -> Result<Self::Parameters, Error> {
+            Ok(())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            _parameters: &Self::Parameters,
+            input: T,
+        ) -> Result<Self::Output, Error> {
+            let mut dig = D::new();
+            dig.update(to_bytes!(input.borrow()).unwrap());
+            Ok(dig.finalize().to_vec())
+        }
+    }
+
+    struct LeafIdentityHasher;
+
+    impl CRHScheme for LeafIdentityHasher {
+        type Input = Vec<u8>;
+        type Output = Vec<u8>;
+        type Parameters = ();
+
+        fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+            Ok(())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            _: &Self::Parameters,
+            input: T,
+        ) -> Result<Self::Output, Error> {
+            Ok(input.borrow().to_vec().into())
+        }
+    }
+
+    struct MerkleTreeParams; //<F, D>(PhantomData<(F, D)>);
 
     impl Config for MerkleTreeParams {
-        type Leaf = [u8];
+        type Leaf = Vec<u8>;
 
         type LeafDigest = <LeafH as CRHScheme>::Output;
         type LeafInnerDigestConverter = ByteDigestConverter<Self::LeafDigest>;
@@ -46,24 +103,17 @@ mod tests {
         type TwoToOneHash = CompressH;
     }
 
-    type MTConfig = MerkleTreeParams;
-    type Sponge = PoseidonSponge<Fr>;
+    type MTConfig = MerkleTreeParams; //<F, Blake2s256>;
+    type Sponge<F> = PoseidonSponge<F>;
 
-    type LigeroPCS = LinearCodePCS<
-        MultilinearLigero<Fr, MTConfig, Blake2s256, Sponge, SparseMultilinearExtension<Fr>>,
-        Fr,
-        SparseMultilinearExtension<Fr>,
-        Sponge,
-        MTConfig,
-        Blake2s256,
-    >;
-    type LigeroPcsF<F> = LinearCodePCS<
-        MultilinearLigero<F, MTConfig, Blake2s256, Sponge, SparseMultilinearExtension<F>>,
+    type LigeroPCS<F> = LinearCodePCS<
+        MultilinearLigero<F, MTConfig, Blake2s256, Sponge<F>, SparseMultilinearExtension<F>>,
         F,
         SparseMultilinearExtension<F>,
-        Sponge,
+        Sponge<F>,
         MTConfig,
         Blake2s256,
+        ColHasher<F, Blake2s256>,
     >;
 
     fn rand_poly<Fr: PrimeField>(
@@ -100,17 +150,20 @@ mod tests {
         let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng)
             .unwrap()
             .clone();
+        let col_hash_params = <ColHasher<Fr, Blake2s256> as CRHScheme>::setup(&mut rng).unwrap();
         let check_well_formedness = true;
 
-        let pp: LinCodePCUniversalParams<Fr, MTConfig> = LinCodePCUniversalParams::new(
-            128,
-            4,
-            check_well_formedness,
-            leaf_hash_params,
-            two_to_one_params,
-        );
+        let pp: LinCodePCUniversalParams<Fr, MTConfig, ColHasher<Fr, Blake2s256>> =
+            LinCodePCUniversalParams::new(
+                128,
+                4,
+                check_well_formedness,
+                leaf_hash_params,
+                two_to_one_params,
+                col_hash_params,
+            );
 
-        let (ck, vk) = LigeroPCS::trim(&pp, 0, 0, None).unwrap();
+        let (ck, vk) = LigeroPCS::<Fr>::trim(&pp, 0, 0, None).unwrap();
 
         let rand_chacha = &mut ChaCha20Rng::from_rng(test_rng()).unwrap();
         let labeled_poly = LabeledPolynomial::new(
@@ -121,7 +174,7 @@ mod tests {
         );
 
         let mut test_sponge = test_sponge::<Fr>();
-        let (c, rands) = LigeroPCS::commit(&ck, &[labeled_poly.clone()], None).unwrap();
+        let (c, rands) = LigeroPCS::<Fr>::commit(&ck, &[labeled_poly.clone()], None).unwrap();
 
         let point = rand_point(Some(5), rand_chacha);
 
@@ -130,7 +183,7 @@ mod tests {
         let mut challenge_generator: ChallengeGenerator<Fr, PoseidonSponge<Fr>> =
             ChallengeGenerator::new_univariate(&mut test_sponge);
 
-        let proof = LigeroPCS::open(
+        let proof = LigeroPCS::<Fr>::open(
             &ck,
             &[labeled_poly],
             &c,
@@ -140,7 +193,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(LigeroPCS::check(
+        assert!(LigeroPCS::<Fr>::check(
             &vk,
             &c,
             &point,
@@ -174,14 +227,14 @@ mod tests {
     #[test]
     fn single_poly_test() {
         use crate::tests::*;
-        single_poly_test::<_, _, LigeroPCS, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr>, _>(
             Some(5),
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
         .expect("test failed for bls12-377");
-        single_poly_test::<_, _, LigeroPcsF<Fr381>, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(10),
             rand_poly::<Fr381>,
             rand_point::<Fr381>,
@@ -193,14 +246,14 @@ mod tests {
     #[test]
     fn constant_poly_test() {
         use crate::tests::*;
-        single_poly_test::<_, _, LigeroPCS, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr>, _>(
             Some(10),
             constant_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
         .expect("test failed for bls12-377");
-        single_poly_test::<_, _, LigeroPcsF<Fr381>, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(5),
             constant_poly::<Fr381>,
             rand_point::<Fr381>,
@@ -212,7 +265,7 @@ mod tests {
     #[test]
     fn full_end_to_end_test() {
         use crate::tests::*;
-        full_end_to_end_test::<_, _, LigeroPCS, _>(
+        full_end_to_end_test::<_, _, LigeroPCS<Fr>, _>(
             Some(8),
             rand_poly::<Fr>,
             rand_point::<Fr>,
@@ -220,7 +273,7 @@ mod tests {
         )
         .expect("test failed for bls12-377");
         println!("Finished bls12-377");
-        full_end_to_end_test::<_, _, LigeroPcsF<Fr381>, _>(
+        full_end_to_end_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(3),
             rand_poly::<Fr381>,
             rand_point::<Fr381>,
@@ -233,7 +286,7 @@ mod tests {
     #[test]
     fn single_equation_test() {
         use crate::tests::*;
-        single_equation_test::<_, _, LigeroPCS, _>(
+        single_equation_test::<_, _, LigeroPCS<Fr>, _>(
             Some(10),
             rand_poly::<Fr>,
             rand_point::<Fr>,
@@ -241,7 +294,7 @@ mod tests {
         )
         .expect("test failed for bls12-377");
         println!("Finished bls12-377");
-        single_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
+        single_equation_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(5),
             rand_poly::<Fr381>,
             rand_point::<Fr381>,
@@ -254,7 +307,7 @@ mod tests {
     #[test]
     fn two_equation_test() {
         use crate::tests::*;
-        two_equation_test::<_, _, LigeroPCS, _>(
+        two_equation_test::<_, _, LigeroPCS<Fr>, _>(
             Some(5),
             rand_poly::<Fr>,
             rand_point::<Fr>,
@@ -262,7 +315,7 @@ mod tests {
         )
         .expect("test failed for bls12-377");
         println!("Finished bls12-377");
-        two_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
+        two_equation_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(10),
             rand_poly::<Fr381>,
             rand_point::<Fr381>,
@@ -275,7 +328,7 @@ mod tests {
     #[test]
     fn full_end_to_end_equation_test() {
         use crate::tests::*;
-        full_end_to_end_equation_test::<_, _, LigeroPCS, _>(
+        full_end_to_end_equation_test::<_, _, LigeroPCS<Fr>, _>(
             Some(5),
             rand_poly::<Fr>,
             rand_point::<Fr>,
@@ -283,7 +336,7 @@ mod tests {
         )
         .expect("test failed for bls12-377");
         println!("Finished bls12-377");
-        full_end_to_end_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
+        full_end_to_end_equation_test::<_, _, LigeroPCS<Fr381>, _>(
             Some(8),
             rand_poly::<Fr381>,
             rand_point::<Fr381>,

--- a/src/linear_codes/transcript.rs
+++ b/src/linear_codes/transcript.rs
@@ -1,0 +1,87 @@
+use core::marker::PhantomData;
+
+use ark_ff::PrimeField;
+use ark_serialize::CanonicalSerialize;
+use merlin::Transcript;
+
+use crate::{to_bytes, Error};
+
+/// The following struct is taken from jellyfish repository. Once they change
+/// their dependency on `crypto-primitive`, we use their crate instead of
+/// a copy-paste. We needed the newer `crypto-primitive` for serializing.
+#[derive(Clone)]
+pub(crate) struct IOPTranscript<F: PrimeField> {
+    transcript: Transcript,
+    is_empty: bool,
+    #[doc(hidden)]
+    phantom: PhantomData<F>,
+}
+
+// TODO: merge this with jf_plonk::transcript
+impl<F: PrimeField> IOPTranscript<F> {
+    /// Create a new IOP transcript.
+    pub(crate) fn new(label: &'static [u8]) -> Self {
+        Self {
+            transcript: Transcript::new(label),
+            is_empty: true,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Append the message to the transcript.
+    pub(crate) fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), Error> {
+        self.transcript.append_message(label, msg);
+        self.is_empty = false;
+        Ok(())
+    }
+
+    /// Append the message to the transcript.
+    pub(crate) fn append_serializable_element<S: CanonicalSerialize>(
+        &mut self,
+        label: &'static [u8],
+        group_elem: &S,
+    ) -> Result<(), Error> {
+        self.append_message(
+            label,
+            &to_bytes!(group_elem).map_err(|_| Error::TranscriptError)?,
+        )
+    }
+
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// The output field element is statistical uniform as long
+    /// as the field has a size less than 2^384.
+    pub(crate) fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Result<F, Error> {
+        //  we need to reject when transcript is empty
+        if self.is_empty {
+            return Err(Error::TranscriptError);
+        }
+
+        let mut buf = [0u8; 64];
+        self.transcript.challenge_bytes(label, &mut buf);
+        let challenge = F::from_le_bytes_mod_order(&buf);
+        self.append_serializable_element(label, &challenge)?;
+        Ok(challenge)
+    }
+
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// Without exposing the internal field `transcript`,
+    /// this is a wrapper around getting bytes as opposed to field elements.
+    pub(crate) fn get_and_append_byte_challenge(
+        &mut self,
+        label: &'static [u8],
+        dest: &mut [u8],
+    ) -> Result<(), Error> {
+        //  we need to reject when transcript is empty
+        if self.is_empty {
+            return Err(Error::TranscriptError);
+        }
+
+        self.transcript.challenge_bytes(label, dest);
+        self.append_message(label, dest)?;
+        Ok(())
+    }
+}

--- a/src/linear_codes/transcript.rs
+++ b/src/linear_codes/transcript.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use ark_ff::BigInteger;
 
@@ -15,12 +16,41 @@ use poseidon_native::Poseidon;
 use crate::Error;
 
 #[derive(Clone)]
+pub(crate) enum Operation {
+    Update(Vec<Fr>, String),
+    Squeeze(Vec<Fr>, String),
+}
+
+#[derive(Clone)]
 pub(crate) struct IOPTranscript<F>
 where
     F: PrimeField,
 {
     pub(crate) sponge: Poseidon<Fr, 3, 2>,
+    operations: Vec<Operation>,
     phantom: PhantomData<F>,
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let (op, elems, tag) = match self {
+            Operation::Update(elems, tag) => ("Update", elems, tag),
+            Operation::Squeeze(elems, tag) => ("Squeeze", elems, tag),
+        };
+
+        writeln!(
+            f,
+            "{op} ({} element{}), tag: \"{tag}\"",
+            elems.len(),
+            if elems.len() == 1 { "" } else { "s" }
+        )?;
+
+        for e in elems {
+            writeln!(f, "    {e:?}")?;
+        }
+
+        FmtResult::Ok(())
+    }
 }
 
 impl<F> IOPTranscript<F>
@@ -30,21 +60,30 @@ where
     pub(crate) fn new(_label: &'static [u8]) -> Self {
         Self {
             sponge: Poseidon::<Fr, 3, 2>::new(8, 57),
+            operations: Vec::new(),
             phantom: PhantomData,
         }
     }
 
-    fn absorb(&mut self, elements: &[F]) {
+    fn absorb(&mut self, label: &'static [u8], elements: &[F]) {
+        let mut temp_halo_values = Vec::new();
         for elem in elements {
             let bytes = BigInteger::to_bytes_le(&elem.into_bigint());
             let halo2_base_elem = Fr::from_bytes_le(&bytes);
+            temp_halo_values.push(halo2_base_elem);
             self.sponge.update(&[halo2_base_elem]);
         }
+        self.operations.push(Operation::Update(
+            temp_halo_values,
+            String::from_utf8(label.to_vec()).unwrap(),
+        ));
     }
 
     fn squeeze(&mut self) -> F {
         let halo2_out = self.sponge.squeeze();
         let out = F::from_le_bytes_mod_order(&halo2_out.to_bytes());
+        self.operations
+            .push(Operation::Squeeze(vec![halo2_out], "squeeze".into()));
         out
     }
 
@@ -56,37 +95,56 @@ where
         &mut self,
         _label: &'static [u8],
         n: usize,
-    ) -> Result<Vec<u8>, Error> {
-        let out = self.sponge.squeeze();
-        let bits = out
-            .to_u64_limbs(Fr::NUM_BITS as usize, 1)
-            .into_iter()
-            .map(|x| {
-                // println!("x: {}", x);
-                x as u8
+        t: usize,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let mut tmp_outs = Vec::new();
+
+        let outer_bits = (0..t)
+            .map(|_| {
+                let out = self.sponge.squeeze();
+                tmp_outs.push(out);
+                let bits = out
+                    .to_u64_limbs(Fr::NUM_BITS as usize, 1)
+                    .into_iter()
+                    .map(|x| x as u8)
+                    .collect::<Vec<u8>>();
+                bits[..(log2(n) as usize)].to_vec()
             })
-            .collect::<Vec<u8>>();
-        let bits = bits[..(log2(n) as usize)].to_vec();
-        Ok(bits)
+            .collect();
+        self.operations
+            .push(Operation::Squeeze(tmp_outs, "column indices".into()));
+        Ok(outer_bits)
     }
 
     /// Append the message to the transcript.
     pub(crate) fn append_field_elements(
         &mut self,
-        _label: &'static [u8],
+        label: &'static [u8],
         group_elem: &[F],
     ) -> Result<(), Error> {
-        self.absorb(group_elem);
+        self.absorb(label, group_elem);
         Ok(())
     }
 
     /// Append the message to the transcript.
     pub(crate) fn append_serializable_element(
         &mut self,
-        _label: &'static [u8],
+        label: &'static [u8],
         group_elem: &F,
     ) -> Result<(), Error> {
-        self.absorb(&[*group_elem]);
+        self.absorb(label, &[*group_elem]);
         Ok(())
+    }
+}
+
+impl<F: PrimeField> Display for IOPTranscript<F> {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        writeln!(f, "{} operations:", self.operations.len())?;
+
+        for (i, e) in self.operations.iter().enumerate() {
+            write!(f, " {}. {}", i + 1, e)?;
+        }
+
+        FmtResult::Ok(())
     }
 }

--- a/src/linear_codes/transcript.rs
+++ b/src/linear_codes/transcript.rs
@@ -1,87 +1,92 @@
 use core::marker::PhantomData;
 
+use ark_ff::BigInteger;
+
 use ark_ff::PrimeField;
-use ark_serialize::CanonicalSerialize;
-use merlin::Transcript;
 
-use crate::{to_bytes, Error};
+use ark_std::log2;
+use halo2_base::halo2_proofs::halo2curves::group::ff::PrimeField as _;
+use halo2_base::utils::ScalarField;
 
-/// The following struct is taken from jellyfish repository. Once they change
-/// their dependency on `crypto-primitive`, we use their crate instead of
-/// a copy-paste. We needed the newer `crypto-primitive` for serializing.
+use halo2_base::halo2_proofs::halo2curves::bn256::Fr;
+
+use poseidon_native::Poseidon;
+
+use crate::Error;
+
 #[derive(Clone)]
-pub(crate) struct IOPTranscript<F: PrimeField> {
-    transcript: Transcript,
-    is_empty: bool,
-    #[doc(hidden)]
+pub(crate) struct IOPTranscript<F>
+where
+    F: PrimeField,
+{
+    pub(crate) sponge: Poseidon<Fr, 3, 2>,
     phantom: PhantomData<F>,
 }
 
-// TODO: merge this with jf_plonk::transcript
-impl<F: PrimeField> IOPTranscript<F> {
-    /// Create a new IOP transcript.
-    pub(crate) fn new(label: &'static [u8]) -> Self {
+impl<F> IOPTranscript<F>
+where
+    F: PrimeField,
+{
+    pub(crate) fn new(_label: &'static [u8]) -> Self {
         Self {
-            transcript: Transcript::new(label),
-            is_empty: true,
+            sponge: Poseidon::<Fr, 3, 2>::new(8, 57),
             phantom: PhantomData,
         }
     }
 
+    fn absorb(&mut self, elements: &[F]) {
+        for elem in elements {
+            let bytes = BigInteger::to_bytes_le(&elem.into_bigint());
+            let halo2_base_elem = Fr::from_bytes_le(&bytes);
+            self.sponge.update(&[halo2_base_elem]);
+        }
+    }
+
+    fn squeeze(&mut self) -> F {
+        let halo2_out = self.sponge.squeeze();
+        let out = F::from_le_bytes_mod_order(&halo2_out.to_bytes());
+        out
+    }
+
+    pub(crate) fn get_and_append_challenge(&mut self, _label: &'static [u8]) -> Result<F, Error> {
+        Ok(self.squeeze())
+    }
+
+    pub(crate) fn get_and_append_byte_challenge(
+        &mut self,
+        _label: &'static [u8],
+        n: usize,
+    ) -> Result<Vec<u8>, Error> {
+        let out = self.sponge.squeeze();
+        let bits = out
+            .to_u64_limbs(Fr::NUM_BITS as usize, 1)
+            .into_iter()
+            .map(|x| {
+                // println!("x: {}", x);
+                x as u8
+            })
+            .collect::<Vec<u8>>();
+        let bits = bits[..(log2(n) as usize)].to_vec();
+        Ok(bits)
+    }
+
     /// Append the message to the transcript.
-    pub(crate) fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), Error> {
-        self.transcript.append_message(label, msg);
-        self.is_empty = false;
+    pub(crate) fn append_field_elements(
+        &mut self,
+        _label: &'static [u8],
+        group_elem: &[F],
+    ) -> Result<(), Error> {
+        self.absorb(group_elem);
         Ok(())
     }
 
     /// Append the message to the transcript.
-    pub(crate) fn append_serializable_element<S: CanonicalSerialize>(
+    pub(crate) fn append_serializable_element(
         &mut self,
-        label: &'static [u8],
-        group_elem: &S,
+        _label: &'static [u8],
+        group_elem: &F,
     ) -> Result<(), Error> {
-        self.append_message(
-            label,
-            &to_bytes!(group_elem).map_err(|_| Error::TranscriptError)?,
-        )
-    }
-
-    /// Generate the challenge from the current transcript
-    /// and append it to the transcript.
-    ///
-    /// The output field element is statistical uniform as long
-    /// as the field has a size less than 2^384.
-    pub(crate) fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Result<F, Error> {
-        //  we need to reject when transcript is empty
-        if self.is_empty {
-            return Err(Error::TranscriptError);
-        }
-
-        let mut buf = [0u8; 64];
-        self.transcript.challenge_bytes(label, &mut buf);
-        let challenge = F::from_le_bytes_mod_order(&buf);
-        self.append_serializable_element(label, &challenge)?;
-        Ok(challenge)
-    }
-
-    /// Generate the challenge from the current transcript
-    /// and append it to the transcript.
-    ///
-    /// Without exposing the internal field `transcript`,
-    /// this is a wrapper around getting bytes as opposed to field elements.
-    pub(crate) fn get_and_append_byte_challenge(
-        &mut self,
-        label: &'static [u8],
-        dest: &mut [u8],
-    ) -> Result<(), Error> {
-        //  we need to reject when transcript is empty
-        if self.is_empty {
-            return Err(Error::TranscriptError);
-        }
-
-        self.transcript.challenge_bytes(label, dest);
-        self.append_message(label, dest)?;
+        self.absorb(&[*group_elem]);
         Ok(())
     }
 }

--- a/src/linear_codes/univariate_ligero/mod.rs
+++ b/src/linear_codes/univariate_ligero/mod.rs
@@ -1,11 +1,8 @@
 use ark_crypto_primitives::{merkle_tree::Config, sponge::CryptographicSponge};
 use ark_ff::PrimeField;
 use ark_poly::DenseUVPolynomial;
-use ark_std::borrow::Borrow;
 use ark_std::marker::PhantomData;
 use ark_std::vec::Vec;
-
-use digest::Digest;
 
 use super::utils::reed_solomon;
 use super::LinearEncode;
@@ -21,21 +18,18 @@ mod tests;
 pub struct UnivariateLigero<
     F: PrimeField,
     C: Config,
-    D: Digest,
     S: CryptographicSponge,
     P: DenseUVPolynomial<F>,
 > {
-    _phantom: PhantomData<(F, C, D, S, P)>,
+    _phantom: PhantomData<(F, C, S, P)>,
 }
 
-impl<F, C, D, S, P> LinearEncode<F, P, C, D> for UnivariateLigero<F, C, D, S, P>
+impl<F, C, S, P> LinearEncode<F, P, C> for UnivariateLigero<F, C, S, P>
 where
     F: PrimeField,
     C: Config,
-    D: Digest,
     S: CryptographicSponge,
     P: DenseUVPolynomial<F>,
-    Vec<u8>: Borrow<C::Leaf>,
     P::Point: Into<F>,
 {
     fn encode(msg: &[F], rho_inv: usize) -> Vec<F> {
@@ -45,10 +39,6 @@ where
     /// For a univariate polynomial, we simply return the list of coefficients.ś
     fn poly_repr(polynomial: &P) -> Vec<F> {
         polynomial.coeffs().to_vec()
-    }
-
-    fn point_to_vec(point: P::Point) -> Vec<F> {
-        vec![point]
     }
 
     /// Compute out = [1, z, z^2, ..., z^(n_cols_1)]

--- a/src/linear_codes/univariate_ligero/tests.rs
+++ b/src/linear_codes/univariate_ligero/tests.rs
@@ -33,6 +33,7 @@ mod tests {
 
     type LeafH = Sha256;
     type CompressH = Sha256;
+    type ColHasher = Sha256;
 
     struct MerkleTreeParams;
 
@@ -56,6 +57,7 @@ mod tests {
         DensePolynomial<Fr>,
         Sponge,
         MTConfig,
+        ColHasher,
         Blake2s256,
     >;
     type LigeroPcsF<F> = LinearCodePCS<
@@ -64,6 +66,7 @@ mod tests {
         DensePolynomial<F>,
         Sponge,
         MTConfig,
+        ColHasher,
         Blake2s256,
     >;
 

--- a/src/linear_codes/univariate_ligero/tests.rs
+++ b/src/linear_codes/univariate_ligero/tests.rs
@@ -1,73 +1,143 @@
 #[cfg(test)]
 mod tests {
 
+    use core::borrow::Borrow;
+    use core::marker::PhantomData;
+
     use crate::ark_std::UniformRand;
     use crate::linear_codes::LinearCodePCS;
+    use crate::PolynomialCommitment;
     use crate::{
         challenge::ChallengeGenerator,
-        linear_codes::{
-            utils::*, LinCodePCUniversalParams, PolynomialCommitment, UnivariateLigero,
-        },
+        linear_codes::{utils::*, LinCodePCUniversalParams, UnivariateLigero},
         LabeledPolynomial,
     };
-    use ark_bls12_377::Fq;
-    use ark_bls12_377::Fr;
-    use ark_bls12_381::Fr as Fr381;
+    use ark_bn254::Fr;
+    use ark_crypto_primitives::merkle_tree::IdentityDigestConverter;
+    use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
+    use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
+    use ark_crypto_primitives::Error;
     use ark_crypto_primitives::{
-        crh::{pedersen, sha256::Sha256, CRHScheme, TwoToOneCRHScheme},
-        merkle_tree::{ByteDigestConverter, Config},
+        crh::{CRHScheme, TwoToOneCRHScheme},
+        merkle_tree::Config,
         sponge::poseidon::PoseidonSponge,
     };
     use ark_ff::{Field, PrimeField};
     use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
     use ark_std::test_rng;
-    use blake2::Blake2s256;
+    use rand_chacha::rand_core::RngCore;
     use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
-    #[derive(Clone)]
-    pub(super) struct Window4x256;
-    impl pedersen::Window for Window4x256 {
-        const WINDOW_SIZE: usize = 4;
-        const NUM_WINDOWS: usize = 256;
+    // We introduce the wrapper only for the purpose of `setup` function not panicing with unimplemented
+    struct PoseidonWrapper<F>(PhantomData<F>);
+
+    impl<F: PrimeField + Absorb> CRHScheme for PoseidonWrapper<F> {
+        type Input = [F];
+        type Output = F;
+        type Parameters = PoseidonConfig<F>;
+
+        fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+            Ok(poseidon_parameters_for_test())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            parameters: &Self::Parameters,
+            input: T,
+        ) -> Result<Self::Output, Error> {
+            let input = input.borrow();
+
+            let mut sponge = PoseidonSponge::new(parameters);
+            sponge.absorb(&input);
+            let res = sponge.squeeze_field_elements::<F>(1);
+            Ok(res[0])
+        }
     }
 
-    type LeafH = Sha256;
-    type CompressH = Sha256;
-    type ColHasher = Sha256;
+    impl<F: PrimeField + Absorb> TwoToOneCRHScheme for PoseidonWrapper<F> {
+        type Input = F;
+        type Output = F;
+        type Parameters = PoseidonConfig<F>;
 
-    struct MerkleTreeParams;
+        fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+            Ok(poseidon_parameters_for_test())
+        }
 
-    impl Config for MerkleTreeParams {
-        type Leaf = [u8];
+        fn evaluate<T: Borrow<Self::Input>>(
+            parameters: &Self::Parameters,
+            left_input: T,
+            right_input: T,
+        ) -> Result<Self::Output, Error> {
+            let left_input = left_input.borrow();
+            let right_input = right_input.borrow();
 
-        type LeafDigest = <LeafH as CRHScheme>::Output;
-        type LeafInnerDigestConverter = ByteDigestConverter<Self::LeafDigest>;
-        type InnerDigest = <CompressH as TwoToOneCRHScheme>::Output;
+            let mut sponge = PoseidonSponge::new(parameters);
+            sponge.absorb(left_input);
+            sponge.absorb(right_input);
+            let res = sponge.squeeze_field_elements::<F>(1);
+            Ok(res[0])
+        }
 
-        type LeafHash = LeafH;
-        type TwoToOneHash = CompressH;
+        fn compress<T: Borrow<Self::Output>>(
+            parameters: &Self::Parameters,
+            left_input: T,
+            right_input: T,
+        ) -> Result<Self::Output, Error> {
+            let left_input = left_input.borrow();
+            let right_input = right_input.borrow();
+
+            let mut sponge = PoseidonSponge::new(parameters);
+            sponge.absorb(left_input);
+            sponge.absorb(right_input);
+            let res = sponge.squeeze_field_elements::<F>(1);
+            Ok(res[0])
+        }
     }
 
-    type MTConfig = MerkleTreeParams;
-    type Sponge = PoseidonSponge<Fr>;
+    type ColHasher<F> = PoseidonWrapper<F>;
+    type CompressH<F> = PoseidonWrapper<F>;
 
-    type LigeroPCS = LinearCodePCS<
-        UnivariateLigero<Fr, MTConfig, Blake2s256, Sponge, DensePolynomial<Fr>>,
-        Fr,
-        DensePolynomial<Fr>,
-        Sponge,
-        MTConfig,
-        ColHasher,
-        Blake2s256,
-    >;
-    type LigeroPcsF<F> = LinearCodePCS<
-        UnivariateLigero<F, MTConfig, Blake2s256, Sponge, DensePolynomial<F>>,
+    struct LeafIdentityHasher<F>(PhantomData<F>);
+
+    impl<F: PrimeField> CRHScheme for LeafIdentityHasher<F> {
+        type Input = F;
+        type Output = F;
+        type Parameters = ();
+
+        fn setup<R: RngCore>(_: &mut R) -> Result<Self::Parameters, Error> {
+            Ok(())
+        }
+
+        fn evaluate<T: Borrow<Self::Input>>(
+            _: &Self::Parameters,
+            input: T,
+        ) -> Result<Self::Output, Error> {
+            Ok(*input.borrow())
+        }
+    }
+
+    struct MerkleTreeParams<F>(PhantomData<F>);
+
+    impl<F: PrimeField + Absorb> Config for MerkleTreeParams<F> {
+        type Leaf = F;
+
+        type LeafDigest = <LeafIdentityHasher<F> as CRHScheme>::Output;
+        type LeafInnerDigestConverter = IdentityDigestConverter<Self::LeafDigest>;
+        type InnerDigest = <CompressH<F> as TwoToOneCRHScheme>::Output;
+
+        type LeafHash = LeafIdentityHasher<F>;
+        type TwoToOneHash = CompressH<F>;
+    }
+
+    type MTConfig<F> = MerkleTreeParams<F>;
+    type Sponge<F> = PoseidonSponge<F>;
+
+    type LigeroPCS<F> = LinearCodePCS<
+        UnivariateLigero<F, MTConfig<F>, Sponge<F>, DensePolynomial<F>>,
         F,
         DensePolynomial<F>,
-        Sponge,
-        MTConfig,
-        ColHasher,
-        Blake2s256,
+        Sponge<F>,
+        MTConfig<F>,
+        ColHasher<F>,
     >;
 
     fn rand_poly<Fr: PrimeField>(
@@ -89,23 +159,23 @@ mod tests {
     #[test]
     fn test_construction() {
         let degree = 4;
-        let mut rng = &mut test_rng();
         // just to make sure we have the right degree given the FFT domain for our field
-        let leaf_hash_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
-        let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng)
-            .unwrap()
-            .clone();
+        let leaf_hash_params = ();
+        let col_hash_params = poseidon_parameters_for_test();
+        let two_to_one_params = poseidon_parameters_for_test();
         let check_well_formedness = true;
 
-        let pp: LinCodePCUniversalParams<Fr, MTConfig> = LinCodePCUniversalParams::new(
-            128,
-            4,
-            check_well_formedness,
-            leaf_hash_params,
-            two_to_one_params,
-        );
+        let pp: LinCodePCUniversalParams<Fr, MTConfig<Fr>, ColHasher<Fr>> =
+            LinCodePCUniversalParams::new(
+                128,
+                4,
+                check_well_formedness,
+                leaf_hash_params,
+                two_to_one_params,
+                col_hash_params,
+            );
 
-        let (ck, vk) = LigeroPCS::trim(&pp, 0, 0, None).unwrap();
+        let (ck, vk) = LigeroPCS::<Fr>::trim(&pp, 0, 0, None).unwrap();
 
         let rand_chacha = &mut ChaCha20Rng::from_rng(test_rng()).unwrap();
         let labeled_poly = LabeledPolynomial::new(
@@ -116,7 +186,7 @@ mod tests {
         );
 
         let mut test_sponge = test_sponge::<Fr>();
-        let (c, rands) = LigeroPCS::commit(&ck, &[labeled_poly.clone()], None).unwrap();
+        let (c, rands) = LigeroPCS::<Fr>::commit(&ck, &[labeled_poly.clone()], None).unwrap();
 
         let point = Fr::rand(rand_chacha);
 
@@ -125,7 +195,7 @@ mod tests {
         let mut challenge_generator: ChallengeGenerator<Fr, PoseidonSponge<Fr>> =
             ChallengeGenerator::new_univariate(&mut test_sponge);
 
-        let proof = LigeroPCS::open(
+        let proof = LigeroPCS::<Fr>::open(
             &ck,
             &[labeled_poly],
             &c,
@@ -135,7 +205,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(LigeroPCS::check(
+        assert!(LigeroPCS::<Fr>::check(
             &vk,
             &c,
             &point,
@@ -147,18 +217,6 @@ mod tests {
         .unwrap());
     }
 
-    #[test]
-    fn test_calculate_t_with_good_parameters() {
-        assert!(calculate_t::<Fq>(128, 4, 2_usize.pow(32)).unwrap() < 200);
-        assert!(calculate_t::<Fq>(256, 4, 2_usize.pow(32)).unwrap() < 400);
-    }
-
-    #[test]
-    fn test_calculate_t_with_bad_parameters() {
-        calculate_t::<Fq>((Fq::MODULUS_BIT_SIZE - 60) as usize, 4, 2_usize.pow(60)).unwrap_err();
-        calculate_t::<Fq>(400, 4, 2_usize.pow(32)).unwrap_err();
-    }
-
     fn rand_point<F: Field>(_: Option<usize>, rng: &mut ChaCha20Rng) -> F {
         F::rand(rng)
     }
@@ -166,240 +224,138 @@ mod tests {
     #[test]
     fn single_poly_test() {
         use crate::tests::*;
-        single_poly_test::<_, _, LigeroPCS, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        single_poly_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn constant_poly_test() {
         use crate::tests::*;
-        single_poly_test::<_, _, LigeroPCS, _>(
+        single_poly_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             constant_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        single_poly_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            constant_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn quadratic_poly_degree_bound_multiple_queries_test() {
         use crate::tests::*;
-        quadratic_poly_degree_bound_multiple_queries_test::<_, _, LigeroPCS, _>(
+        quadratic_poly_degree_bound_multiple_queries_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        quadratic_poly_degree_bound_multiple_queries_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn linear_poly_degree_bound_test() {
         use crate::tests::*;
-        linear_poly_degree_bound_test::<_, _, LigeroPCS, _>(
+        linear_poly_degree_bound_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        linear_poly_degree_bound_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn single_poly_degree_bound_test() {
         use crate::tests::*;
-        single_poly_degree_bound_test::<_, _, LigeroPCS, _>(
+        single_poly_degree_bound_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        single_poly_degree_bound_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn single_poly_degree_bound_multiple_queries_test() {
         use crate::tests::*;
-        single_poly_degree_bound_multiple_queries_test::<_, _, LigeroPCS, _>(
+        single_poly_degree_bound_multiple_queries_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        single_poly_degree_bound_multiple_queries_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn two_polys_degree_bound_single_query_test() {
         use crate::tests::*;
-        two_polys_degree_bound_single_query_test::<_, _, LigeroPCS, _>(
+        two_polys_degree_bound_single_query_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        two_polys_degree_bound_single_query_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn full_end_to_end_test() {
         use crate::tests::*;
-        full_end_to_end_test::<_, _, LigeroPCS, _>(
+        full_end_to_end_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
-        full_end_to_end_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
-        println!("Finished bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn single_equation_test() {
         use crate::tests::*;
-        single_equation_test::<_, _, LigeroPCS, _>(
+        single_equation_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
-        single_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
-        println!("Finished bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn two_equation_test() {
         use crate::tests::*;
-        two_equation_test::<_, _, LigeroPCS, _>(
+        two_equation_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
-        two_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
-        println!("Finished bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn two_equation_degree_bound_test() {
         use crate::tests::*;
-        two_equation_degree_bound_test::<_, _, LigeroPCS, _>(
+        two_equation_degree_bound_test::<_, _, LigeroPCS<Fr>, _>(
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
-        two_equation_degree_bound_test::<_, _, LigeroPcsF<Fr381>, _>(
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
-        println!("Finished bls12-381");
+        .expect("test failed for bn254");
     }
 
     #[test]
     fn full_end_to_end_equation_test() {
         use crate::tests::*;
-        full_end_to_end_equation_test::<_, _, LigeroPCS, _>(
+        full_end_to_end_equation_test::<_, _, LigeroPCS<Fr>, _>(
             None,
             rand_poly::<Fr>,
             rand_point::<Fr>,
             poseidon_sponge_for_test,
         )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
-        full_end_to_end_equation_test::<_, _, LigeroPcsF<Fr381>, _>(
-            None,
-            rand_poly::<Fr381>,
-            rand_point::<Fr381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-381");
-        println!("Finished bls12-381");
-    }
-
-    #[test]
-    #[should_panic]
-    fn bad_degree_bound_test() {
-        use crate::tests::*;
-        use ark_bls12_381::Fq as Fq381;
-        bad_degree_bound_test::<_, _, LigeroPcsF<Fq381>, _>(
-            rand_poly::<Fq381>,
-            rand_point::<Fq381>,
-            poseidon_sponge_for_test,
-        )
-        .expect("test failed for bls12-377");
-        println!("Finished bls12-377");
+        .expect("test failed for bn254");
     }
 }

--- a/src/linear_codes/utils.rs
+++ b/src/linear_codes/utils.rs
@@ -1,9 +1,8 @@
-use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
 use ark_ff::{FftField, Field, PrimeField};
 
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
+use ark_std::string::ToString;
 use ark_std::vec::Vec;
-use ark_std::{string::ToString, test_rng};
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 #[cfg(feature = "parallel")]
@@ -167,16 +166,14 @@ pub(crate) fn to_field<F: Field>(v: Vec<u64>) -> Vec<F> {
     v.iter().map(|x| F::from(*x)).collect::<Vec<F>>()
 }
 
-#[inline]
-pub(crate) fn get_num_bytes(n: usize) -> usize {
-    ceil_div((usize::BITS - n.leading_zeros()) as usize, 8)
-}
-
 // TODO: replace by https://github.com/arkworks-rs/crypto-primitives/issues/112.
 #[cfg(test)]
-use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
+use ark_crypto_primitives::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
 
+#[cfg(test)]
 pub(crate) fn poseidon_parameters_for_test<F: PrimeField>() -> PoseidonConfig<F> {
+    use ark_std::test_rng;
+
     let full_rounds = 8;
     let partial_rounds = 31;
     let alpha = 17;
@@ -382,16 +379,5 @@ mod tests {
                 assert_eq!(pol.evaluate(&large_domain.element(j)), encoded[j]);
             }
         }
-    }
-
-    #[test]
-    fn test_get_num_bytes() {
-        assert_eq!(get_num_bytes(0), 0);
-        assert_eq!(get_num_bytes(1), 1);
-        assert_eq!(get_num_bytes(9), 1);
-        assert_eq!(get_num_bytes(1 << 11), 2);
-        assert_eq!(get_num_bytes(1 << 32 - 1), 4);
-        assert_eq!(get_num_bytes(1 << 32), 5);
-        assert_eq!(get_num_bytes(1 << 32 + 1), 5);
     }
 }

--- a/src/linear_codes/utils.rs
+++ b/src/linear_codes/utils.rs
@@ -233,12 +233,10 @@ pub(crate) fn get_indices_from_transcript<F: PrimeField>(
         .map_err(|_| Error::TranscriptError)?;
     for i in 0..t {
         // get the usize from Vec<u8>:
-        println!("bits[i]: {:?}", bits[i]);
         let ind = bits[i]
             .iter()
             .rev()
             .fold(0, |acc, &x| (acc << 1) + x as usize);
-        println!("ind: {}", ind);
         indices.push(ind);
     }
     Ok(indices)

--- a/src/linear_codes/utils.rs
+++ b/src/linear_codes/utils.rs
@@ -228,13 +228,16 @@ pub(crate) fn get_indices_from_transcript<F: PrimeField>(
     transcript: &mut IOPTranscript<F>,
 ) -> Result<Vec<usize>, Error> {
     let mut indices = Vec::with_capacity(t);
-    for _ in 0..t {
-        let bits = transcript
-            .get_and_append_byte_challenge(b"i", n)
-            .map_err(|_| Error::TranscriptError)?;
-
+    let bits = transcript
+        .get_and_append_byte_challenge(b"i", n, t)
+        .map_err(|_| Error::TranscriptError)?;
+    for i in 0..t {
         // get the usize from Vec<u8>:
-        let ind = bits.iter().fold(0, |acc, &x| (acc << 1) + x as usize);
+        println!("bits[i]: {:?}", bits[i]);
+        let ind = bits[i]
+            .iter()
+            .rev()
+            .fold(0, |acc, &x| (acc << 1) + x as usize);
         println!("ind: {}", ind);
         indices.push(ind);
     }

--- a/src/linear_codes/utils.rs
+++ b/src/linear_codes/utils.rs
@@ -1,6 +1,3 @@
-use core::borrow::Borrow;
-
-use ark_crypto_primitives::{crh::CRHScheme, merkle_tree::Config};
 use ark_ff::{FftField, Field, PrimeField};
 
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
@@ -300,21 +297,6 @@ impl<F: PrimeField> IOPTranscript<F> {
         self.append_message(label, dest)?;
         Ok(())
     }
-}
-
-#[inline]
-pub(crate) fn hash_column<F, C, H>(array: Vec<F>, params: &H::Parameters) -> Result<C::Leaf, Error>
-where
-    F: PrimeField,
-    C: Config,
-    H: CRHScheme,
-    Vec<F>: Borrow<<H as CRHScheme>::Input>,
-    C::Leaf: Sized,
-    H::Output: Into<C::Leaf>,
-{
-    H::evaluate(params, array)
-        .map_err(|_| Error::HashingError)
-        .map(|x| x.into())
 }
 
 /// Generate `t` (not necessarily distinct) random points in `[0, n)` using the current state of `transcript`

--- a/src/linear_codes/utils.rs
+++ b/src/linear_codes/utils.rs
@@ -1,11 +1,8 @@
 use ark_ff::{FftField, Field, PrimeField};
 
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use ark_serialize::CanonicalSerialize;
-use ark_std::marker::PhantomData;
 use ark_std::string::ToString;
 use ark_std::vec::Vec;
-use merlin::Transcript;
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 #[cfg(feature = "parallel")]
@@ -177,6 +174,8 @@ pub(crate) fn get_num_bytes(n: usize) -> usize {
 // TODO: replace by https://github.com/arkworks-rs/crypto-primitives/issues/112.
 #[cfg(test)]
 use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
+
+use super::transcript::IOPTranscript;
 #[cfg(test)]
 pub(crate) fn test_sponge<F: PrimeField>() -> PoseidonSponge<F> {
     use ark_crypto_primitives::sponge::{poseidon::PoseidonConfig, CryptographicSponge};
@@ -217,86 +216,6 @@ macro_rules! to_bytes {
         let mut buf = ark_std::vec![];
         ark_serialize::CanonicalSerialize::serialize_compressed($x, &mut buf).map(|_| buf)
     }};
-}
-
-/// The following struct is taken from jellyfish repository. Once they change
-/// their dependency on `crypto-primitive`, we use their crate instead of
-/// a copy-paste. We needed the newer `crypto-primitive` for serializing.
-#[derive(Clone)]
-pub(crate) struct IOPTranscript<F: PrimeField> {
-    transcript: Transcript,
-    is_empty: bool,
-    #[doc(hidden)]
-    phantom: PhantomData<F>,
-}
-
-// TODO: merge this with jf_plonk::transcript
-impl<F: PrimeField> IOPTranscript<F> {
-    /// Create a new IOP transcript.
-    pub(crate) fn new(label: &'static [u8]) -> Self {
-        Self {
-            transcript: Transcript::new(label),
-            is_empty: true,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Append the message to the transcript.
-    pub(crate) fn append_message(&mut self, label: &'static [u8], msg: &[u8]) -> Result<(), Error> {
-        self.transcript.append_message(label, msg);
-        self.is_empty = false;
-        Ok(())
-    }
-
-    /// Append the message to the transcript.
-    pub(crate) fn append_serializable_element<S: CanonicalSerialize>(
-        &mut self,
-        label: &'static [u8],
-        group_elem: &S,
-    ) -> Result<(), Error> {
-        self.append_message(
-            label,
-            &to_bytes!(group_elem).map_err(|_| Error::TranscriptError)?,
-        )
-    }
-
-    /// Generate the challenge from the current transcript
-    /// and append it to the transcript.
-    ///
-    /// The output field element is statistical uniform as long
-    /// as the field has a size less than 2^384.
-    pub(crate) fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Result<F, Error> {
-        //  we need to reject when transcript is empty
-        if self.is_empty {
-            return Err(Error::TranscriptError);
-        }
-
-        let mut buf = [0u8; 64];
-        self.transcript.challenge_bytes(label, &mut buf);
-        let challenge = F::from_le_bytes_mod_order(&buf);
-        self.append_serializable_element(label, &challenge)?;
-        Ok(challenge)
-    }
-
-    /// Generate the challenge from the current transcript
-    /// and append it to the transcript.
-    ///
-    /// Without exposing the internal field `transcript`,
-    /// this is a wrapper around getting bytes as opposed to field elements.
-    pub(crate) fn get_and_append_byte_challenge(
-        &mut self,
-        label: &'static [u8],
-        dest: &mut [u8],
-    ) -> Result<(), Error> {
-        //  we need to reject when transcript is empty
-        if self.is_empty {
-            return Err(Error::TranscriptError);
-        }
-
-        self.transcript.challenge_bytes(label, dest);
-        self.append_message(label, dest)?;
-        Ok(())
-    }
 }
 
 /// Generate `t` (not necessarily distinct) random points in `[0, n)` using the current state of `transcript`


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

There's a bunch of changes that are needed to make arkworks PCS compatible with the halo2 PCS.

Most are innocuous (e.g. making parameters `pub` instead of `pub(crate`), but there are a few major refactors:
1. pp/vk/ck now hold an extra set of parameters `col_hash_params: H::Parameters`: this is to ensure that we can specify the hash function for hashing the columns. Previously we were using a Digest, which only worked with bytes - now we need the "digest" to be field elements.
2. `hash_column` is gone and replaced by a direct call to `H: CRHScheme`: see above. It added a bound `Vec<F>: Borrow<<H as CRHScheme>::Input>` since we need to ensure that field elements can be the input to `H`.
3. Moved `IOPTranscript` to its own file and changed its functionality substantially:
    - split out absorbing field elements which are matrix coefficients or encoding thereof, from absorbing merkle tree root (this can probably be reverted, it's a legacy from a wrong path I took while refactoring)
    - introduced different trait bounds on `PolynomialCommitment`. Now we force: e.g. `C: Config + Config<InnerDigest = F>` since the outputs of leaf hashing in MT are fields.
4. Temporarily removed `univariate` module from `lib.rs` so cargo doesn't complain. For this project we don't care about univariate anyway, but should be brought back at some point maybe.

In its current form this PR is incompatible with the changes from #3 - #3 should be merged first and then I can rebase on top of it. Most changes should not conflict though.